### PR TITLE
Symmetric dispute game

### DIFF
--- a/src/auto-disputer.ts
+++ b/src/auto-disputer.ts
@@ -1,0 +1,121 @@
+import _ from 'lodash';
+import {ChallengeManager, expectedNumOfLeaves, State, stepForIndex} from './bisection';
+import {Role} from './bisection.test';
+
+class AutoDisputerAgent {
+  constructor(
+    public role: Role,
+    public cm: ChallengeManager,
+    public myStates: State[],
+    public numSplits: number
+  ) {}
+
+  private splitStates(agreeWithStep: number, disagreeWithStep: number): State[] {
+    const initialStates: State[] = [];
+
+    for (let i = 0; i < expectedNumOfLeaves(agreeWithStep, disagreeWithStep, this.numSplits); i++) {
+      const index = stepForIndex(i, agreeWithStep, disagreeWithStep, this.numSplits);
+      initialStates.push(this.myStates[index]);
+    }
+
+    return initialStates;
+  }
+
+  public takeTurn(): {complete: boolean; detectedFraud: boolean} {
+    if (this.cm.caller === this.role) {
+      throw new Error(`It's not my turn!`);
+    }
+    const disagreeWithIndex = this.firstDisputedIndex();
+    const agreeWithStep = this.cm.stepForIndex(disagreeWithIndex - 1);
+    const disagreeWithStep = this.cm.stepForIndex(disagreeWithIndex);
+
+    if (this.cm.interval() > 1 && disagreeWithStep - agreeWithStep > 1) {
+      let leaves = this.splitStates(agreeWithStep, disagreeWithStep);
+
+      // We only want the leaves so we slice off the parent
+      leaves = leaves.slice(1);
+
+      this.cm.split(
+        this.cm.states[disagreeWithIndex - 1],
+        leaves,
+        this.cm.states[disagreeWithIndex],
+        this.role
+      );
+
+      return {complete: false, detectedFraud: false};
+    } else {
+      const disagreeWithIndex = this.firstDisputedIndex();
+      const consensusWitness = {witness: this.cm.states[disagreeWithIndex - 1]};
+      const disputedWitness = {witness: this.cm.states[disagreeWithIndex]};
+
+      const detectedFraud =
+        this.cm.interval() <= 1 ? this.cm.detectFraud(consensusWitness, disputedWitness) : false;
+      return {complete: true, detectedFraud};
+    }
+  }
+
+  private firstDisputedIndex(): number {
+    for (let i = 0; i < this.cm.states.length; i++) {
+      const step = this.cm.stepForIndex(i);
+      if (this.cm.states[i].root !== this.myStates[step].root) {
+        return i;
+      }
+    }
+    throw 'Did not find disputed state';
+  }
+}
+export class AutomaticDisputer {
+  private cm: ChallengeManager;
+  challenger: AutoDisputerAgent;
+  proposer: AutoDisputerAgent;
+
+  constructor(
+    public numSplits: number,
+    public challengerStates: State[],
+    public proposerStates: State[]
+  ) {
+    const initialStates = [];
+    for (let i = 0; i < expectedNumOfLeaves(0, proposerStates.length - 1, numSplits); i++) {
+      const index = i === 0 ? 0 : stepForIndex(i, 0, proposerStates.length - 1, numSplits);
+      initialStates.push(proposerStates[index]);
+    }
+
+    this.cm = new ChallengeManager(
+      initialStates,
+      state => ({root: state.root + 1}),
+      state => state.root,
+      'proposer',
+      this.challengerStates.length - 1,
+      this.numSplits
+    );
+
+    this.proposer = new AutoDisputerAgent('proposer', this.cm, this.proposerStates, this.numSplits);
+    this.challenger = new AutoDisputerAgent(
+      'challenger',
+      this.cm,
+      this.challengerStates,
+      this.numSplits
+    );
+  }
+
+  private takeTurn(): {complete: boolean; detectedFraud: boolean} {
+    if (this.cm.caller === 'challenger') {
+      return this.proposer.takeTurn();
+    } else {
+      return this.challenger.takeTurn();
+    }
+  }
+
+  public runDispute(expectedStates: State[], expectedFraud: boolean) {
+    let isComplete = false;
+    let detectedFraud = false;
+    while (!isComplete) {
+      const result = this.takeTurn();
+      isComplete = result.complete;
+      detectedFraud = result.detectedFraud;
+    }
+
+    expect(this.cm.states).toMatchObject(expectedStates);
+    expect(detectedFraud).toBe(expectedFraud);
+  }
+}

--- a/src/bisection.ts
+++ b/src/bisection.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-
+import util from 'util';
 type Bytes32 = number;
 
 export type State = {root: Bytes32};
@@ -41,7 +41,7 @@ export function stepForIndex(
  * @param numSplits
  * @returns A decimal interval.
  */
-function interval(consensusStep: number, highestStep: number, numSplits: number): number {
+export function interval(consensusStep: number, highestStep: number, numSplits: number): number {
   const stepsBetweenConsensusAndHighest = highestStep - consensusStep;
   return stepsBetweenConsensusAndHighest / numSplits;
 }
@@ -81,7 +81,7 @@ export class ChallengeManager {
     }
   }
 
-  private interval(): number {
+  public interval(): number {
     return interval(this.consensusStep, this.highestStep, this.numSplits);
   }
 


### PR DESCRIPTION
This branch converts the dispute game to be symmetric.
1. The challenger initializes the `ChallengeManager` with a set of commitments.
2. The proposer finds the commitment with the largest step that the proposer agrees with. The proposer then calls `split` to dissect the commitment range between the agreed commitment and the disputed commitment.
3. The challenger and proposer alternate calling `split` until the agreed commitment is the commitment before the disputed commitment (or until `disputeFraud` can be invoked without running out of gas).

Interesting work remaining for this PR is:
- [x] Eliminate the explicit `step` field from the `StepCommitment` 
- [ ] In Solidity, it will be impractical to store the list of commitments. Instead, we'll store the hash of `(consensusIndex, highestIndex, merkleRootOfCommitments)`