### PR TITLE
Implement merkle proofs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dependencies": {
         "ethers": "^5.4.5",
         "js-sha3": "^0.8.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "merkle-tools": "^1.4.1"
     },
     "scripts": {
         "test": "jest",

--- a/src/auto-disputer.ts
+++ b/src/auto-disputer.ts
@@ -9,7 +9,7 @@ import {
   WitnessProof
 } from './bisection';
 import {fingerprint, Role} from './bisection.test';
-import {generateWitness, generateWitnessFromHashes} from './merkle';
+import {generateWitness} from './merkle';
 
 class AutoDisputerAgent {
   constructor(
@@ -37,8 +37,8 @@ class AutoDisputerAgent {
     const disagreeWithIndex = this.firstDisputedIndex();
     const agreeWithStep = this.cm.stepForIndex(disagreeWithIndex - 1);
     const disagreeWithStep = this.cm.stepForIndex(disagreeWithIndex);
-    const consensusWitness = generateWitnessFromHashes(this.cm.stateHashes, disagreeWithIndex - 1);
-    const disputedWitness = generateWitnessFromHashes(this.cm.stateHashes, disagreeWithIndex);
+    const consensusWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex - 1);
+    const disputedWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex);
     if (this.cm.interval() > 1) {
       let leaves = this.splitStates(agreeWithStep, disagreeWithStep);
 
@@ -51,11 +51,8 @@ class AutoDisputerAgent {
     } else {
       const disagreeWithIndex = this.firstDisputedIndex();
 
-      const consensusWitness = generateWitnessFromHashes(
-        this.cm.stateHashes,
-        disagreeWithIndex - 1
-      );
-      const disputedWitness = generateWitnessFromHashes(this.cm.stateHashes, disagreeWithIndex);
+      const consensusWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex - 1);
+      const disputedWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex);
       const detectedFraud =
         this.cm.interval() <= 1
           ? this.cm.detectFraud(

--- a/src/auto-disputer.ts
+++ b/src/auto-disputer.ts
@@ -1,15 +1,8 @@
 import _ from 'lodash';
 import MerkleTree from 'merkle-tools';
-import {
-  ChallengeManager,
-  expectedNumOfLeaves,
-  State,
-  stepForIndex,
-  Hash,
-  WitnessProof
-} from './bisection';
+import {ChallengeManager, expectedNumOfLeaves, State, stepForIndex} from './bisection';
 import {fingerprint, Role} from './bisection.test';
-import {generateWitness} from './merkle';
+import {generateWitness, Hash} from './merkle';
 
 class AutoDisputerAgent {
   constructor(

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -56,6 +56,15 @@ test('manual bisection', () => {
 
   expect(() =>
     cm.split(
+      generateWitness(fingerprints(incorrectStates, [4, 5, 6]), 0),
+      fingerprints(correctStates, [5, 6]),
+      generateWitness(cm.stateHashes, 2),
+      challengerId
+    )
+  ).toThrowError('Invalid consensus witness proof');
+
+  expect(() =>
+    cm.split(
       generateWitness(cm.stateHashes, 1),
       fingerprints(correctStates, [5, 6]),
       generateWitness(fingerprints(correctStates, [0, 1, 2]), 2),

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -93,16 +93,16 @@ test('manual tri-section', () => {
   const consensusWitness = generateWitnessFromHashes(cm.stateHashes, 1);
   const disputeWitness = generateWitnessFromHashes(cm.stateHashes, 2);
 
-  cm.split(consensusWitness, fingerprints(incorrectStates, [4, 5, 6]), disputeWitness, proposerId);
+  cm.split(consensusWitness, fingerprints(incorrectStates, [4, 5, 7]), disputeWitness, proposerId);
 
   // These would be pulled from the call data of our opponents transaction
-  const previousStateHashes = _.cloneDeep(cm.stateHashes.slice(1));
+  const previousStateHashes = _.cloneDeep(cm.stateHashes);
 
   expect(
     cm.detectFraud(
-      generateWitnessFromHashes(previousStateHashes, 0),
+      generateWitnessFromHashes(previousStateHashes, 1),
       {root: 4},
-      generateWitnessFromHashes(previousStateHashes, 1)
+      generateWitnessFromHashes(previousStateHashes, 2)
     )
   ).toBe(true);
 });

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -1,4 +1,4 @@
-import {ChallengeManager, State, WitnessProof} from './bisection';
+import {ChallengeManager, State} from './bisection';
 import _ from 'lodash';
 import {AutomaticDisputer} from './auto-disputer';
 import {sha3_256} from 'js-sha3';

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -1,86 +1,25 @@
-import {ChallengeManager, State, Witness} from './bisection';
+import {ChallengeManager, State, WitnessProof} from './bisection';
 import _ from 'lodash';
 import {AutomaticDisputer} from './auto-disputer';
 import {sha3_256} from 'js-sha3';
+import {generateWitness} from './merkle';
 
 export type Role = 'challenger' | 'proposer';
 const challengerId = 'challenger' as const;
 const proposerId = 'proposer' as const;
-
 function states(values: number[], indices: number[]): State[] {
   return indices.map(step => ({root: values[step]}));
 }
-
 function state(values: number[], index: number): State {
   return {root: values[index]};
 }
-
-export const fingerprint = (state: State) => sha3_256(state.root.toString());
-
 function fingerprints(values: number[], indices: number[]) {
   return states(values, indices).map(fingerprint);
 }
-
-function witness(values: number[], index: number): Witness {
-  return {witness: fingerprint(state(values, index))};
+function witness(values: number[], indices: number[], index: number): WitnessProof {
+  return generateWitness(states(values, indices), index);
 }
-
-test('manual bisection', () => {
-  const incorrectStates = [0, 1, 2, 3, 4, 5.1, 6.1, 7.1, 8.1, 9.1];
-  const correctStates = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-  const cm = new ChallengeManager(
-    fingerprints(correctStates, [0, 4, 9]),
-    state => ({root: state.root + 1}),
-    fingerprint,
-    challengerId,
-    9,
-    2
-  );
-
-  cm.split(
-    witness(incorrectStates, 4),
-    fingerprints(incorrectStates, [6, 9]),
-    witness(correctStates, 9),
-    proposerId
-  );
-
-  expect(() =>
-    cm.split(
-      witness(incorrectStates, 9),
-      fingerprints(correctStates, [9]),
-      witness(incorrectStates, 9),
-      challengerId
-    )
-  ).toThrowError('Consensus witness cannot be the last stored state');
-
-  expect(() =>
-    cm.split(
-      witness(correctStates, 1),
-      fingerprints(correctStates, [2, 9]),
-      witness(incorrectStates, 9),
-      challengerId
-    )
-  ).toThrowError('Consensus witness is not in the stored states');
-
-  expect(() =>
-    cm.split(
-      witness(correctStates, 4),
-      fingerprints(correctStates, [5, 6]),
-      witness(correctStates, 6),
-      challengerId
-    )
-  ).toThrowError('Disputed witness does not match');
-
-  cm.split(
-    witness(correctStates, 4),
-    fingerprints(correctStates, [5, 6]),
-    witness(incorrectStates, 6),
-    challengerId
-  );
-  expect(cm.detectFraud(witness(correctStates, 5), {root: 5}, witness(correctStates, 6))).toBe(
-    false
-  );
-});
+export const fingerprint = (state: State) => sha3_256(state.root.toString());
 
 test('manual tri-section', () => {
   const incorrectStates = [0, 1, 2, 3, 4, 5.1, 6.1, 7.1, 8.1, 9.1];
@@ -94,15 +33,17 @@ test('manual tri-section', () => {
     3
   );
 
-  cm.split(
-    witness(incorrectStates, 3),
-    fingerprints(incorrectStates, [4, 5, 6]),
-    witness(correctStates, 6),
-    proposerId
-  );
-  expect(cm.detectFraud(witness(incorrectStates, 4), {root: 4}, witness(incorrectStates, 5))).toBe(
-    true
-  );
+  const consensusWitness = witness(correctStates, [0, 3, 6, 9], 1);
+  const disputeWitness = witness(correctStates, [0, 3, 6, 9], 2);
+  cm.split(consensusWitness, fingerprints(incorrectStates, [4, 5, 6]), disputeWitness, proposerId);
+
+  expect(
+    cm.detectFraud(
+      witness(incorrectStates, [4, 5, 6], 0),
+      {root: 4},
+      witness(incorrectStates, [4, 5, 6], 1)
+    )
+  ).toBe(true);
 });
 
 const amountOfStates = 90;

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -2,7 +2,7 @@ import {ChallengeManager, State, WitnessProof} from './bisection';
 import _ from 'lodash';
 import {AutomaticDisputer} from './auto-disputer';
 import {sha3_256} from 'js-sha3';
-import {generateWitness, generateWitnessFromHashes} from './merkle';
+import {generateWitness} from './merkle';
 
 export type Role = 'challenger' | 'proposer';
 const challengerId = 'challenger' as const;
@@ -29,52 +29,52 @@ test('manual bisection', () => {
     2
   );
   cm.split(
-    generateWitnessFromHashes(cm.stateHashes, 1),
+    generateWitness(cm.stateHashes, 1),
     fingerprints(incorrectStates, [6, 9]),
-    generateWitnessFromHashes(cm.stateHashes, 2),
+    generateWitness(cm.stateHashes, 2),
     proposerId
   );
 
   expect(() =>
     cm.split(
-      generateWitnessFromHashes(cm.stateHashes, 2),
+      generateWitness(cm.stateHashes, 2),
 
       fingerprints(correctStates, [9]),
-      generateWitnessFromHashes(cm.stateHashes, 2),
+      generateWitness(cm.stateHashes, 2),
       challengerId
     )
   ).toThrowError('Consensus witness cannot be the last stored state');
 
   expect(() =>
     cm.split(
-      generateWitnessFromHashes(fingerprints(correctStates, [5, 6, 7]), 1),
+      generateWitness(fingerprints(correctStates, [5, 6, 7]), 1),
       fingerprints(correctStates, [2, 9]),
-      generateWitnessFromHashes(cm.stateHashes, 2),
+      generateWitness(cm.stateHashes, 2),
       challengerId
     )
   ).toThrowError('Consensus witness is not in the stored states');
 
   expect(() =>
     cm.split(
-      generateWitnessFromHashes(cm.stateHashes, 1),
+      generateWitness(cm.stateHashes, 1),
       fingerprints(correctStates, [5, 6]),
-      generateWitnessFromHashes(fingerprints(correctStates, [0, 1, 2]), 2),
+      generateWitness(fingerprints(correctStates, [0, 1, 2]), 2),
       challengerId
     )
   ).toThrowError('Invalid dispute witness proof');
 
   cm.split(
-    generateWitnessFromHashes(cm.stateHashes, 0),
+    generateWitness(cm.stateHashes, 0),
     fingerprints(correctStates, [5, 6]),
-    generateWitnessFromHashes(cm.stateHashes, 1),
+    generateWitness(cm.stateHashes, 1),
     challengerId
   );
 
   expect(
     cm.detectFraud(
-      generateWitnessFromHashes(cm.stateHashes, 1),
+      generateWitness(cm.stateHashes, 1),
       {root: 5},
-      generateWitnessFromHashes(cm.stateHashes, 2)
+      generateWitness(cm.stateHashes, 2)
     )
   ).toBe(false);
 });
@@ -90,16 +90,16 @@ test('manual tri-section', () => {
     3
   );
 
-  const consensusWitness = generateWitnessFromHashes(cm.stateHashes, 1);
-  const disputeWitness = generateWitnessFromHashes(cm.stateHashes, 2);
+  const consensusWitness = generateWitness(cm.stateHashes, 1);
+  const disputeWitness = generateWitness(cm.stateHashes, 2);
 
   cm.split(consensusWitness, fingerprints(incorrectStates, [4, 5, 7]), disputeWitness, proposerId);
 
   expect(
     cm.detectFraud(
-      generateWitnessFromHashes(cm.stateHashes, 1),
+      generateWitness(cm.stateHashes, 1),
       {root: 4},
-      generateWitnessFromHashes(cm.stateHashes, 2)
+      generateWitness(cm.stateHashes, 2)
     )
   ).toBe(true);
 });

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -69,12 +69,12 @@ test('manual bisection', () => {
     generateWitnessFromHashes(cm.stateHashes, 1),
     challengerId
   );
-  const previousStateHashes = _.cloneDeep(cm.stateHashes);
+
   expect(
     cm.detectFraud(
-      generateWitnessFromHashes(previousStateHashes, 1),
+      generateWitnessFromHashes(cm.stateHashes, 1),
       {root: 5},
-      generateWitnessFromHashes(previousStateHashes, 2)
+      generateWitnessFromHashes(cm.stateHashes, 2)
     )
   ).toBe(false);
 });
@@ -95,14 +95,11 @@ test('manual tri-section', () => {
 
   cm.split(consensusWitness, fingerprints(incorrectStates, [4, 5, 7]), disputeWitness, proposerId);
 
-  // These would be pulled from the call data of our opponents transaction
-  const previousStateHashes = _.cloneDeep(cm.stateHashes);
-
   expect(
     cm.detectFraud(
-      generateWitnessFromHashes(previousStateHashes, 1),
+      generateWitnessFromHashes(cm.stateHashes, 1),
       {root: 4},
-      generateWitnessFromHashes(previousStateHashes, 2)
+      generateWitnessFromHashes(cm.stateHashes, 2)
     )
   ).toBe(true);
 });

--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -107,8 +107,8 @@ test('manual tri-section', () => {
   ).toBe(true);
 });
 
-const amountOfStates = 90;
-const maxSplits = 90;
+const amountOfStates = 25;
+const maxSplits = 25;
 
 test('Fuzzy testing', () => {
   for (let errorIndex = 1; errorIndex < amountOfStates; errorIndex++) {

--- a/src/bisection.ts
+++ b/src/bisection.ts
@@ -1,13 +1,8 @@
 import _ from 'lodash';
-import {Proof as MerkleToolsProof} from 'merkle-tools';
-import {generateRoot, validateWitness} from './merkle';
-type Proof = MerkleToolsProof<string>[];
+import {generateRoot, Hash, validateWitness, WitnessProof} from './merkle';
+
 type Bytes32 = number;
-export type Hash = string;
-export type WitnessProof = {
-  witness: Hash;
-  proof: Proof;
-};
+
 export type State = {root: Bytes32};
 
 // Helper functions for indices <-> steps

--- a/src/bisection.ts
+++ b/src/bisection.ts
@@ -106,6 +106,13 @@ export class ChallengeManager {
     if (this.interval() <= 1) {
       throw new Error('States cannot be split further');
     }
+    const consensusIndex = this.stateHashes.findIndex(hash => hash === consensusWitness.witness);
+    if (consensusIndex < 0) {
+      throw new Error('Consensus witness is not in the stored states');
+    }
+    if (consensusIndex === this.numSplits) {
+      throw new Error('Consensus witness cannot be the last stored state');
+    }
 
     const validConsensusWitness = validateWitness(consensusWitness, this.root);
     if (!validConsensusWitness) {
@@ -116,7 +123,6 @@ export class ChallengeManager {
     if (!validDisputeWitness) {
       throw new Error('Invalid dispute witness proof');
     }
-    const consensusIndex = this.stateHashes.findIndex(hash => hash === consensusWitness.witness);
     if (hashes[hashes.length - 1] === disputedWitness.witness) {
       throw new Error('The last state supplied must differ from the disputed witness');
     }

--- a/src/merkle.test.ts
+++ b/src/merkle.test.ts
@@ -1,0 +1,20 @@
+import {sha3_256} from 'js-sha3';
+import {generateRoot, generateWitness, validateWitness} from './merkle';
+
+test('it returns false  when the proof is invalid for the root', () => {
+  const validHashes = ['a', 'b', 'c'].map(sha3_256);
+  const invalidHashses = ['a', 'b', 'INVALID'].map(sha3_256);
+  const invalidRoot = generateRoot(invalidHashses);
+  const witnessProof = generateWitness(validHashes, 2);
+
+  expect(validateWitness(witnessProof, invalidRoot)).toBe(false);
+});
+
+test('it returns true  for a valid proof and root', () => {
+  const validHashes = ['a', 'b', 'c'].map(sha3_256);
+  const validRoot = generateRoot(validHashes);
+  const witnessProof = generateWitness(validHashes, 2);
+
+  expect(validateWitness(witnessProof, validRoot)).toBe(true);
+});
+14

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -1,16 +1,7 @@
-import {sha3_256} from 'js-sha3';
 import MerkleTree from 'merkle-tools';
-import {Hash, State, WitnessProof} from './bisection';
+import {Hash, WitnessProof} from './bisection';
 
-export const hashState = (state: State) => sha3_256(state.root.toString());
-
-export function generateWitness(states: State[], index: number): WitnessProof {
-  return generateWitnessFromHashes(
-    states.map(s => hashState(s)),
-    index
-  );
-}
-export function generateWitnessFromHashes(hashes: Hash[], index: number): WitnessProof {
+export function generateWitness(hashes: Hash[], index: number): WitnessProof {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
   tree.addLeaves(hashes, false);
   tree.makeTree();
@@ -18,7 +9,6 @@ export function generateWitnessFromHashes(hashes: Hash[], index: number): Witnes
   const root = tree.getMerkleRoot()?.toString('hex');
   const witness = tree.getLeaf(index)?.toString('hex');
   const proof = tree.getProof(index);
-  
 
   if (!root || !witness || !proof) {
     throw new Error('Invalid node or proof!');

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -1,5 +1,14 @@
 import MerkleTree from 'merkle-tools';
-import {Hash, WitnessProof} from './bisection';
+import _ from 'lodash';
+import {Proof as MerkleToolsProof} from 'merkle-tools';
+
+type Proof = MerkleToolsProof<string>[];
+
+export type Hash = string;
+export type WitnessProof = {
+  witness: Hash;
+  proof: Proof;
+};
 
 export function generateWitness(hashes: Hash[], index: number): WitnessProof {
   const tree = new MerkleTree({hashType: 'SHA3-256'});

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -1,0 +1,44 @@
+import {sha3_256} from 'js-sha3';
+import MerkleTree from 'merkle-tools';
+import {Hash, State, WitnessProof} from './bisection';
+
+export const hashState = (state: State) => sha3_256(state.root.toString());
+
+export function generateWitness(states: State[], index: number): WitnessProof {
+  return generateWitnessFromHashes(
+    states.map(s => hashState(s)),
+    index
+  );
+}
+export function generateWitnessFromHashes(hashes: Hash[], index: number): WitnessProof {
+  const tree = new MerkleTree({hashType: 'SHA3-256'});
+  tree.addLeaves(hashes, false);
+  tree.makeTree();
+
+  const root = tree.getMerkleRoot()?.toString('hex');
+  const witness = tree.getLeaf(index)?.toString('hex');
+  const proof = tree.getProof(index);
+  
+
+  if (!root || !witness || !proof) {
+    throw new Error('Invalid node or proof!');
+  }
+  return {witness, proof};
+}
+
+export function validateWitness(witnessProof: WitnessProof, root: string): boolean {
+  const tree = new MerkleTree({hashType: 'SHA3-256'});
+  const {proof, witness} = witnessProof;
+  return tree.validateProof(proof as any, witness, root);
+}
+
+export function generateRoot(stateHashes: Hash[]): Hash {
+  const tree = new MerkleTree({hashType: 'SHA3-256'});
+  tree.addLeaves(stateHashes, false);
+  tree.makeTree();
+  const root = tree.getMerkleRoot();
+  if (!root) {
+    throw new Error('Could not calculate root');
+  }
+  return root.toString('hex');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,6 +2694,13 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merkle-tools@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merkle-tools/-/merkle-tools-1.4.1.tgz#d08799886a6d51f5ee2bf0195f967b3cc3afd62c"
+  integrity sha512-QhO1/eDvAnyn0oXgRWlydVWYVMrVJwrdNICYvQXYhBU1Bjj1LoxsQxdAKJ5ttN3L6pkKhjcK6O4k927kgTMdqw==
+  dependencies:
+    js-sha3 "^0.8.0"
+
 micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"


### PR DESCRIPTION
Constructs and validates merkle proofs for the consensus and dispute node.

`split` and `detectFraud` now take in a new `WitnessProof` type
```
type Proof = MerkleToolsProof<string>[];
export type WitnessProof = {
  witness: Hash;
  proof: Proof;
};
```
The `proof` is a merkle proof generated by  `merkle-tools`  which looks like this:

```
 proof = [
   { right: '09096dbc49b7909917e13b795ebf289ace50b870440f10424af8845fb7761ea5' },
   { right: 'ed2456914e48c1e17b7bd922177291ef8b7f553edf1b1f66b6fc1a076524b22f' },
   { left: 'eac53dde9661daf47a428efea28c81a021c06d64f98eeabbdcff442d992153a8' }
 ]
```

The `ChallengeManager` has been updated to:
- keep track of the current merkle root.
- Validate merkle proofs using `this.root` and the provided `WitnessProof`
