### PR TITLE
Check that the witness is a leaf witness in the challenge manager

### DIFF
--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -87,6 +87,7 @@ test('manual bisection', () => {
     )
   ).toBe(false);
 });
+
 test('manual tri-section', () => {
   const incorrectStates = [0, 1, 2, 3, 4, 5.1, 6.1, 7.1, 8.1, 9.1];
   const correctStates = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/src/bisection.ts
+++ b/src/bisection.ts
@@ -83,6 +83,17 @@ export class ChallengeManager {
     this.root = generateRoot(stateHashes);
   }
 
+  /**
+   * This only works with full, binary trees. For now, we are padding the leaves with leaves of sha256('0').
+   */
+  public get depth() {
+    return Math.ceil(Math.log2(this.expectedNumLeaves()));
+  }
+
+  public expectedNumLeaves(): number {
+    return expectedNumOfLeaves(this.consensusStep, this.disputedStep, this.numSplits);
+  }
+
   public interval(): number {
     return interval(this.consensusStep, this.disputedStep, this.numSplits);
   }
@@ -108,12 +119,12 @@ export class ChallengeManager {
       throw new Error('Consensus witness cannot be the last stored state');
     }
 
-    const validConsensusWitness = validateWitness(consensusWitness, this.root);
+    const validConsensusWitness = validateWitness(consensusWitness, this.root, this.depth);
     if (!validConsensusWitness) {
       throw new Error('Invalid consensus witness proof');
     }
 
-    const validDisputeWitness = validateWitness(disputedWitness, this.root);
+    const validDisputeWitness = validateWitness(disputedWitness, this.root, this.depth);
     if (!validDisputeWitness) {
       throw new Error('Invalid dispute witness proof');
     }
@@ -167,12 +178,12 @@ export class ChallengeManager {
       throw new Error('Consensus state does not match the consensusWitness');
     }
 
-    const validConsensusWitness = validateWitness(consensusWitness, this.root);
+    const validConsensusWitness = validateWitness(consensusWitness, this.root, this.depth);
     if (!validConsensusWitness) {
       throw new Error('Invalid consensus witness proof');
     }
 
-    const validDisputeWitness = validateWitness(disputedWitness, this.root);
+    const validDisputeWitness = validateWitness(disputedWitness, this.root, this.depth);
     if (!validDisputeWitness) {
       throw new Error('Invalid dispute witness proof');
     }

--- a/src/merkle.test.ts
+++ b/src/merkle.test.ts
@@ -17,4 +17,3 @@ test('it returns true  for a valid proof and root', () => {
 
   expect(validateWitness(witnessProof, validRoot, 2)).toBe(true);
 });
-14;

--- a/src/merkle.test.ts
+++ b/src/merkle.test.ts
@@ -7,7 +7,7 @@ test('it returns false  when the proof is invalid for the root', () => {
   const invalidRoot = generateRoot(invalidHashses);
   const witnessProof = generateWitness(validHashes, 2);
 
-  expect(validateWitness(witnessProof, invalidRoot)).toBe(false);
+  expect(validateWitness(witnessProof, invalidRoot, 2)).toBe(false);
 });
 
 test('it returns true  for a valid proof and root', () => {
@@ -15,6 +15,6 @@ test('it returns true  for a valid proof and root', () => {
   const validRoot = generateRoot(validHashes);
   const witnessProof = generateWitness(validHashes, 2);
 
-  expect(validateWitness(witnessProof, validRoot)).toBe(true);
+  expect(validateWitness(witnessProof, validRoot, 2)).toBe(true);
 });
-14
+14;

--- a/src/merkle.test.ts
+++ b/src/merkle.test.ts
@@ -23,7 +23,7 @@ describe('validateWitness checks', () => {
 });
 
 describe('Proof to index checks', () => {
-  it('4 level tree', () => {
+  test('4 level tree', () => {
     const tree = new MerkleTree({hashType: 'SHA3-256'});
     tree.addLeaves(['0', '1', '2', '3', '4', '5', '6', '7'].map(sha3_256), false);
     tree.makeTree();

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -1,5 +1,6 @@
-import MerkleTree from 'merkle-tools';
+import {sha3_256} from 'js-sha3';
 import _ from 'lodash';
+import MerkleTree from 'merkle-tools';
 import {Proof as MerkleToolsProof} from 'merkle-tools';
 
 type Proof = MerkleToolsProof<string>[];
@@ -10,9 +11,16 @@ export type WitnessProof = {
   proof: Proof;
 };
 
+// Used to create a full binary tree.
+function padLeaves(hashes: Hash[]) {
+  const paddingLength = Math.pow(2, Math.ceil(Math.log2(hashes.length))) - hashes.length;
+  const padding = _.range(paddingLength).map(i => sha3_256('0'));
+  return [...hashes, ...padding];
+}
+
 export function generateWitness(hashes: Hash[], index: number): WitnessProof {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
-  tree.addLeaves(hashes, false);
+  tree.addLeaves(padLeaves(hashes), false);
   tree.makeTree();
 
   const root = tree.getMerkleRoot()?.toString('hex');
@@ -25,15 +33,21 @@ export function generateWitness(hashes: Hash[], index: number): WitnessProof {
   return {witness, proof};
 }
 
-export function validateWitness(witnessProof: WitnessProof, root: string): boolean {
+export function validateWitness(witnessProof: WitnessProof, root: string, depth: number): boolean {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
   const {proof, witness} = witnessProof;
+
+  if (witnessProof.proof.length !== depth) {
+    throw new Error(
+      `The witness provided is not for a leaf node. Expected ${depth} witness length, recieved ${witnessProof.proof.length}`
+    );
+  }
   return tree.validateProof(proof as any, witness, root);
 }
 
 export function generateRoot(stateHashes: Hash[]): Hash {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
-  tree.addLeaves(stateHashes, false);
+  tree.addLeaves(padLeaves(stateHashes), false);
   tree.makeTree();
   const root = tree.getMerkleRoot();
   if (!root) {

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -18,6 +18,11 @@ function padLeaves(hashes: Hash[]) {
   return [...hashes, ...padding];
 }
 
+/**
+ * Given a merkle proof for a binary tree, computes the index of the node for the proof.
+ * @param proof A list of siblings ordered from bottom of the tree to the top.
+ * @returns Index of the node.
+ */
 export function proofToIndex(proof: Proof): number {
   let index = 0;
   let pow = 0;


### PR DESCRIPTION
The Challenger Manager must validate that a witness points to a leaf node. There are two approaches to do so:
1. Pad a tree to a full binary tree. With full binary tree, the witness size is function of the number of leaves.
2. Do not expect a full tree. Then, the calculation of whether a witness points to a leaf is more complex. But certainly doable.

In this PR, we are choosing the first approach.