### PR TITLE
ChallengeManager no longer relies on stored hash list

### DIFF
--- a/src/bisection.test.ts
+++ b/src/bisection.test.ts
@@ -52,7 +52,7 @@ test('manual bisection', () => {
       generateWitness(cm.stateHashes, 2),
       challengerId
     )
-  ).toThrowError('Consensus witness is not in the stored states');
+  ).toThrowError('Invalid consensus witness proof');
 
   expect(() =>
     cm.split(

--- a/src/bisection.ts
+++ b/src/bisection.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {generateRoot, Hash, validateWitness, WitnessProof} from './merkle';
+import {generateRoot, Hash, proofToIndex, validateWitness, WitnessProof} from './merkle';
 
 type Bytes32 = number;
 
@@ -111,11 +111,10 @@ export class ChallengeManager {
     if (this.interval() <= 1) {
       throw new Error('States cannot be split further');
     }
-    const consensusIndex = this.stateHashes.findIndex(hash => hash === consensusWitness.witness);
-    if (consensusIndex < 0) {
-      throw new Error('Consensus witness is not in the stored states');
-    }
-    if (consensusIndex === this.numSplits) {
+    const consensusIndex = proofToIndex(consensusWitness.proof);
+    const disputedIndex = proofToIndex(disputedWitness.proof);
+
+    if (consensusIndex >= this.expectedNumLeaves() - 1) {
       throw new Error('Consensus witness cannot be the last stored state');
     }
 
@@ -128,6 +127,11 @@ export class ChallengeManager {
     if (!validDisputeWitness) {
       throw new Error('Invalid dispute witness proof');
     }
+
+    if (consensusIndex + 1 !== disputedIndex) {
+      throw new Error('Disputed state hash must be the next leaf after consensus state hash');
+    }
+
     if (hashes[hashes.length - 1] === disputedWitness.witness) {
       throw new Error('The last state supplied must differ from the disputed witness');
     }
@@ -162,22 +166,6 @@ export class ChallengeManager {
   ): boolean {
     if (this.interval() > 1) throw new Error('Can only detect fraud for sequential states');
 
-    const witnessIndex = this.stateHashes.findIndex(state => state === consensusWitness.witness);
-    if (witnessIndex < 0) {
-      throw new Error('Witness cannot be found in stored states');
-    }
-    if (witnessIndex === this.stateHashes.length - 1) {
-      throw new Error('Witness cannot be the last state');
-    }
-
-    if (this.stateHashes[witnessIndex + 1] !== disputedWitness.witness) {
-      throw new Error('Disputed witness does not match stored states');
-    }
-
-    if (this.fingerprint(consensusState) !== consensusWitness.witness) {
-      throw new Error('Consensus state does not match the consensusWitness');
-    }
-
     const validConsensusWitness = validateWitness(consensusWitness, this.root, this.depth);
     if (!validConsensusWitness) {
       throw new Error('Invalid consensus witness proof');
@@ -188,7 +176,22 @@ export class ChallengeManager {
       throw new Error('Invalid dispute witness proof');
     }
 
+    const consensusIndex = proofToIndex(consensusWitness.proof);
+    const disputedIndex = proofToIndex(disputedWitness.proof);
+
+    if (consensusIndex >= this.expectedNumLeaves() - 1) {
+      throw new Error('Consensus witness cannot be the last stored state');
+    }
+
+    if (consensusIndex + 1 !== disputedIndex) {
+      throw new Error('Disputed state hash must be the next leaf after consensus state hash');
+    }
+
+    if (this.fingerprint(consensusState) !== consensusWitness.witness) {
+      throw new Error('Consensus state does not match the consensusWitness');
+    }
+
     const correctWitnessAfter = this.progress(consensusState);
-    return this.fingerprint(correctWitnessAfter) !== this.stateHashes[witnessIndex + 1];
+    return this.fingerprint(correctWitnessAfter) !== disputedWitness.witness;
   }
 }

--- a/src/merkle.test.ts
+++ b/src/merkle.test.ts
@@ -1,19 +1,36 @@
 import {sha3_256} from 'js-sha3';
-import {generateRoot, generateWitness, validateWitness} from './merkle';
+import _ from 'lodash';
+import MerkleTree from 'merkle-tools';
+import {generateRoot, generateWitness, proofToIndex, validateWitness} from './merkle';
 
-test('it returns false  when the proof is invalid for the root', () => {
-  const validHashes = ['a', 'b', 'c'].map(sha3_256);
-  const invalidHashses = ['a', 'b', 'INVALID'].map(sha3_256);
-  const invalidRoot = generateRoot(invalidHashses);
-  const witnessProof = generateWitness(validHashes, 2);
+describe('validateWitness checks', () => {
+  test('it returns false  when the proof is invalid for the root', () => {
+    const validHashes = ['a', 'b', 'c'].map(sha3_256);
+    const invalidHashses = ['a', 'b', 'INVALID'].map(sha3_256);
+    const invalidRoot = generateRoot(invalidHashses);
+    const witnessProof = generateWitness(validHashes, 2);
 
-  expect(validateWitness(witnessProof, invalidRoot, 2)).toBe(false);
+    expect(validateWitness(witnessProof, invalidRoot, 2)).toBe(false);
+  });
+
+  test('it returns true  for a valid proof and root', () => {
+    const validHashes = ['a', 'b', 'c'].map(sha3_256);
+    const validRoot = generateRoot(validHashes);
+    const witnessProof = generateWitness(validHashes, 2);
+
+    expect(validateWitness(witnessProof, validRoot, 2)).toBe(true);
+  });
 });
 
-test('it returns true  for a valid proof and root', () => {
-  const validHashes = ['a', 'b', 'c'].map(sha3_256);
-  const validRoot = generateRoot(validHashes);
-  const witnessProof = generateWitness(validHashes, 2);
+describe('Proof to index checks', () => {
+  it('4 level tree', () => {
+    const tree = new MerkleTree({hashType: 'SHA3-256'});
+    tree.addLeaves(['0', '1', '2', '3', '4', '5', '6', '7'].map(sha3_256), false);
+    tree.makeTree();
 
-  expect(validateWitness(witnessProof, validRoot, 2)).toBe(true);
+    for (const index of _.range(7)) {
+      const proof = tree.getProof(index);
+      expect(proofToIndex(proof!)).toEqual(index);
+    }
+  });
 });

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -18,6 +18,18 @@ function padLeaves(hashes: Hash[]) {
   return [...hashes, ...padding];
 }
 
+export function proofToIndex(proof: Proof): number {
+  let index = 0;
+  let pow = 0;
+  for (const sibling of proof) {
+    if ('left' in sibling) {
+      index += Math.pow(2, pow);
+    }
+    pow += 1;
+  }
+  return index;
+}
+
 export function generateWitness(hashes: Hash[], index: number): WitnessProof {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
   tree.addLeaves(padLeaves(hashes), false);


### PR DESCRIPTION
Before this PR, the ChallengeManager stored state hashes passed in during initialization and `split` calls. The ChallengeManager has been modified to mimic chain behavior by storing the "last calldata". In practice, this is still the list of state hashes. However, this list is never read internally by the ChallengeManager. It is only used by disputers.