### PR TITLE
Use only index and node hashes for a witness proof

### DIFF
--- a/src/challenge-manager.ts
+++ b/src/challenge-manager.ts
@@ -1,4 +1,4 @@
-import {generateRoot, Hash, proofToIndex, validateWitness, WitnessProof} from './merkle';
+import {generateRoot, Hash, validateWitness, WitnessProof} from './merkle';
 
 type Bytes32 = number;
 
@@ -105,8 +105,8 @@ export class ChallengeManager {
     consensusWitness: WitnessProof,
     disputedWitness: WitnessProof
   ): {consensusIndex: number; disputedIndex: number} {
-    const consensusIndex = proofToIndex(consensusWitness.proof);
-    const disputedIndex = proofToIndex(disputedWitness.proof);
+    const consensusIndex = consensusWitness.index;
+    const disputedIndex = disputedWitness.index;
 
     if (consensusIndex >= this.expectedNumLeaves() - 1) {
       throw new Error('Consensus witness cannot be the last stored state');

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -47,10 +47,11 @@ export function validateWitness(witnessProof: WitnessProof, root: string, depth:
   }
 
   const convertedProof = generateMerkleToolsProof(nodes, index);
-  return tree.validateProof(convertedProof, witness, root);
+  // TODO: The MerkleTools library isn't typed properly so we force a cast here
+  return tree.validateProof(convertedProof as unknown as MerkleToolsProof<string>, witness, root);
 }
 
-function generateMerkleToolsProof(nodes: Hash[], index: number): MerkleToolsProof<string> {
+function generateMerkleToolsProof(nodes: Hash[], index: number): MerkleToolsProof<string>[] {
   const merkleToolsProof: MerkleToolsProof<string>[] = [];
 
   for (let i = 0; i < nodes.length; i++) {
@@ -63,8 +64,7 @@ function generateMerkleToolsProof(nodes: Hash[], index: number): MerkleToolsProo
     index = Math.floor(index / 2);
   }
 
-  // TODO: The MerkleTools library isn't typed properly so we force a cast here
-  return merkleToolsProof as unknown as MerkleToolsProof<string>;
+  return merkleToolsProof;
 }
 
 export function generateRoot(stateHashes: Hash[]): Hash {

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -3,12 +3,11 @@ import _ from 'lodash';
 
 import MerkleTree, {Proof as MerkleToolsProof} from 'merkle-tools';
 
-type Proof = MerkleToolsProof<string>[];
-
 export type Hash = string;
 export type WitnessProof = {
   witness: Hash;
-  proof: Proof;
+  nodes: Hash[];
+  index: number;
 };
 
 // Used to create a full binary tree.
@@ -19,23 +18,6 @@ function padLeaves(hashes: Hash[]) {
   return [...hashes, ...padding];
 }
 
-/**
- * Given a merkle proof for a binary tree, computes the index of the node for the proof.
- * @param proof A list of siblings ordered from bottom of the tree to the top.
- * @returns Index of the node.
- */
-export function proofToIndex(proof: Proof): number {
-  let index = 0;
-  let pow = 0;
-  for (const sibling of proof) {
-    if ('left' in sibling) {
-      index += Math.pow(2, pow);
-    }
-    pow += 1;
-  }
-  return index;
-}
-
 export function generateWitness(hashes: Hash[], index: number): WitnessProof {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
   tree.addLeaves(padLeaves(hashes), false);
@@ -43,25 +25,46 @@ export function generateWitness(hashes: Hash[], index: number): WitnessProof {
 
   const root = tree.getMerkleRoot()?.toString('hex');
   const witness = tree.getLeaf(index)?.toString('hex');
-  const proof = tree.getProof(index);
+  const proof = tree.getProof(index, false);
 
   if (!root || !witness || !proof) {
     throw new Error('Invalid node or proof!');
   }
-  return {witness, proof};
+
+  const nodes = proof.map(p => ('left' in p ? p.left : p.right));
+
+  return {witness, nodes, index};
 }
 
 export function validateWitness(witnessProof: WitnessProof, root: string, depth: number): boolean {
   const tree = new MerkleTree({hashType: 'SHA3-256'});
-  const {proof, witness} = witnessProof;
+  const {index, nodes, witness} = witnessProof;
 
-  if (witnessProof.proof.length !== depth) {
+  if (witnessProof.nodes.length !== depth) {
     throw new Error(
-      `The witness provided is not for a leaf node. Expected ${depth} witness length, recieved ${witnessProof.proof.length}`
+      `The witness provided is not for a leaf node. Expected ${depth} witness length, recieved ${witnessProof.nodes.length}`
     );
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return tree.validateProof(proof as any, witness, root);
+
+  const convertedProof = generateMerkleToolsProof(nodes, index);
+  return tree.validateProof(convertedProof, witness, root);
+}
+
+function generateMerkleToolsProof(nodes: Hash[], index: number): MerkleToolsProof<string> {
+  const merkleToolsProof: MerkleToolsProof<string>[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    if (index % 2 !== 0) {
+      merkleToolsProof.push({left: nodes[i]});
+    } else {
+      merkleToolsProof.push({right: nodes[i]});
+    }
+
+    index = Math.floor(index / 2);
+  }
+
+  // TODO: The MerkleTools library isn't typed properly so we force a cast here
+  return merkleToolsProof as unknown as MerkleToolsProof<string>;
 }
 
 export function generateRoot(stateHashes: Hash[]): Hash {

--- a/src/tests/merkle.test.ts
+++ b/src/tests/merkle.test.ts
@@ -1,7 +1,7 @@
 import {sha3_256} from 'js-sha3';
 import _ from 'lodash';
-import MerkleTree from 'merkle-tools';
-import {generateRoot, generateWitness, validateWitness, proofToIndex} from '../merkle';
+
+import {generateRoot, generateWitness, validateWitness} from '../merkle';
 
 describe('validateWitness checks', () => {
   test('it returns false  when the proof is invalid for the root', () => {
@@ -19,19 +19,5 @@ describe('validateWitness checks', () => {
     const witnessProof = generateWitness(validHashes, 2);
 
     expect(validateWitness(witnessProof, validRoot, 2)).toBe(true);
-  });
-});
-
-describe('Proof to index checks', () => {
-  test('4 level tree', () => {
-    const tree = new MerkleTree({hashType: 'SHA3-256'});
-    tree.addLeaves(['0', '1', '2', '3', '4', '5', '6', '7'].map(sha3_256), false);
-    tree.makeTree();
-
-    for (const index of _.range(7)) {
-      const proof = tree.getProof(index);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(proofToIndex(proof!)).toEqual(index);
-    }
   });
 });

--- a/src/tests/merkle.test.ts
+++ b/src/tests/merkle.test.ts
@@ -13,11 +13,14 @@ describe('validateWitness checks', () => {
     expect(validateWitness(witnessProof, invalidRoot, 2)).toBe(false);
   });
 
-  test('it returns true  for a valid proof and root', () => {
-    const validHashes = ['a', 'b', 'c'].map(sha3_256);
+  test('it returns true for a valid proof and root', () => {
+    const depth = 10;
+    const validHashes = _.range(Math.pow(2, depth)).map(i => sha3_256(i.toString()));
     const validRoot = generateRoot(validHashes);
-    const witnessProof = generateWitness(validHashes, 2);
 
-    expect(validateWitness(witnessProof, validRoot, 2)).toBe(true);
+    for (let index = 0; index < depth; index++) {
+      const witnessProof = generateWitness(validHashes, index);
+      expect(validateWitness(witnessProof, validRoot, depth)).toBe(true);
+    }
   });
 });

--- a/src/tests/merkle.test.ts
+++ b/src/tests/merkle.test.ts
@@ -14,11 +14,11 @@ describe('validateWitness checks', () => {
   });
 
   test('it returns true for a valid proof and root', () => {
-    const depth = 10;
+    const depth = 6;
     const validHashes = _.range(Math.pow(2, depth)).map(i => sha3_256(i.toString()));
     const validRoot = generateRoot(validHashes);
 
-    for (let index = 0; index < depth; index++) {
+    for (let index = 0; index < validHashes.length; index++) {
       const witnessProof = generateWitness(validHashes, index);
       expect(validateWitness(witnessProof, validRoot, depth)).toBe(true);
     }


### PR DESCRIPTION
The proof format we're using from `merkle-tools` currently encodes the path directions in the proof data.
RIght now that's :
```
[{right: 'f9e2eaaa42d9fe9e558a9b8ef1bf366f190aacaa83bad2641ee106e9041096e4'},
{left: '29df505440ebe180c00857e92b0694c56a33762b08944472492b0cbf6ec607e3'}]
```
but we could also get it in binary which looks like:
```
// With asBinary set to true, an array of Buffers is returned 
// 0x00 indicated 'left', 0x01 indicates 'right'
// example: 
// proof == [
//   <Buffer 01>,
//   <Buffer 09096dbc49b7909917e13b795ebf289ace50b870440f10424af8845fb7761ea5>,
//   <Buffer 01>
//   <Buffer ed2456914e48c1e17b7bd922177291ef8b7f553edf1b1f66b6fc1a076524b22f>,
//   <Buffer 00>
//   <Buffer eac53dde9661daf47a428efea28c81a021c06d64f98eeabbdcff442d992153a8>
// ]
```
Instead of having a left/right property (or a boolean flag) I think our proof could just be
```
WitnessProof = {
  witness: Hash;
  nodes: Hash[];
  index: number;
};
```
We can use the `index` to calculate the path which is just the path information expressed as a `uint`. I think this would be more efficient than accepting an array of directions or some other format?


That does mean converting to and from the format for `merkle-tools` but it was pretty easy to handle that.
