### PR TITLE
Rename stateHashes to lastCalldata

### DIFF
--- a/src/auto-disputer.ts
+++ b/src/auto-disputer.ts
@@ -28,8 +28,8 @@ export class AutoDisputerAgent {
     const disagreeWithIndex = this.firstDisputedIndex();
     const agreeWithStep = this.cm.stepForIndex(disagreeWithIndex - 1);
     const disagreeWithStep = this.cm.stepForIndex(disagreeWithIndex);
-    const consensusWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex - 1);
-    const disputedWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex);
+    const consensusWitness = generateWitness(this.cm.lastCalldata, disagreeWithIndex - 1);
+    const disputedWitness = generateWitness(this.cm.lastCalldata, disagreeWithIndex);
     if (this.cm.interval() > 1) {
       let leaves = this.splitStates(agreeWithStep, disagreeWithStep);
 
@@ -42,8 +42,8 @@ export class AutoDisputerAgent {
     } else {
       const disagreeWithIndex = this.firstDisputedIndex();
 
-      const consensusWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex - 1);
-      const disputedWitness = generateWitness(this.cm.stateHashes, disagreeWithIndex);
+      const consensusWitness = generateWitness(this.cm.lastCalldata, disagreeWithIndex - 1);
+      const disputedWitness = generateWitness(this.cm.lastCalldata, disagreeWithIndex);
       const detectedFraud =
         this.cm.interval() <= 1
           ? this.cm.detectFraud(
@@ -57,9 +57,9 @@ export class AutoDisputerAgent {
   }
 
   private firstDisputedIndex(): number {
-    for (let i = 0; i < this.cm.stateHashes.length; i++) {
+    for (let i = 0; i < this.cm.lastCalldata.length; i++) {
       const step = this.cm.stepForIndex(i);
-      if (this.cm.stateHashes[i] !== fingerprint(this.myStates[step])) {
+      if (this.cm.lastCalldata[i] !== fingerprint(this.myStates[step])) {
         return i;
       }
     }
@@ -122,6 +122,6 @@ export class AutomaticDisputer {
       detectedFraud = result.detectedFraud;
     }
 
-    return {detectedFraud, states: this.cm.stateHashes};
+    return {detectedFraud, states: this.cm.lastCalldata};
   }
 }

--- a/src/tests/challenge-manager.test.ts
+++ b/src/tests/challenge-manager.test.ts
@@ -30,18 +30,17 @@ test('manual bisection', () => {
     2
   );
   cm.split(
-    generateWitness(cm.stateHashes, 1),
+    generateWitness(cm.lastCalldata, 1),
     fingerprints(incorrectStates, [6, 9]),
-    generateWitness(cm.stateHashes, 2),
+    generateWitness(cm.lastCalldata, 2),
     proposerId
   );
 
   expect(() =>
     cm.split(
-      generateWitness(cm.stateHashes, 2),
-
+      generateWitness(cm.lastCalldata, 2),
       fingerprints(correctStates, [9]),
-      generateWitness(cm.stateHashes, 2),
+      generateWitness(cm.lastCalldata, 2),
       challengerId
     )
   ).toThrowError('Consensus witness cannot be the last stored state');
@@ -50,7 +49,7 @@ test('manual bisection', () => {
     cm.split(
       generateWitness(fingerprints(correctStates, [5, 6, 7]), 1),
       fingerprints(correctStates, [2, 9]),
-      generateWitness(cm.stateHashes, 2),
+      generateWitness(cm.lastCalldata, 2),
       challengerId
     )
   ).toThrowError('Invalid consensus witness proof');
@@ -59,14 +58,14 @@ test('manual bisection', () => {
     cm.split(
       generateWitness(fingerprints(incorrectStates, [4, 5, 6]), 0),
       fingerprints(correctStates, [5, 6]),
-      generateWitness(cm.stateHashes, 2),
+      generateWitness(cm.lastCalldata, 2),
       challengerId
     )
   ).toThrowError('Invalid consensus witness proof');
 
   expect(() =>
     cm.split(
-      generateWitness(cm.stateHashes, 1),
+      generateWitness(cm.lastCalldata, 1),
       fingerprints(correctStates, [5, 6]),
       generateWitness(fingerprints(correctStates, [0, 1, 2]), 2),
       challengerId
@@ -74,17 +73,17 @@ test('manual bisection', () => {
   ).toThrowError('Invalid dispute witness proof');
 
   cm.split(
-    generateWitness(cm.stateHashes, 0),
+    generateWitness(cm.lastCalldata, 0),
     fingerprints(correctStates, [5, 6]),
-    generateWitness(cm.stateHashes, 1),
+    generateWitness(cm.lastCalldata, 1),
     challengerId
   );
 
   expect(
     cm.detectFraud(
-      generateWitness(cm.stateHashes, 1),
+      generateWitness(cm.lastCalldata, 1),
       {root: 5},
-      generateWitness(cm.stateHashes, 2)
+      generateWitness(cm.lastCalldata, 2)
     )
   ).toBe(false);
 });
@@ -101,16 +100,16 @@ test('manual tri-section', () => {
     3
   );
 
-  const consensusWitness = generateWitness(cm.stateHashes, 1);
-  const disputeWitness = generateWitness(cm.stateHashes, 2);
+  const consensusWitness = generateWitness(cm.lastCalldata, 1);
+  const disputeWitness = generateWitness(cm.lastCalldata, 2);
 
   cm.split(consensusWitness, fingerprints(incorrectStates, [4, 5, 7]), disputeWitness, proposerId);
 
   expect(
     cm.detectFraud(
-      generateWitness(cm.stateHashes, 1),
+      generateWitness(cm.lastCalldata, 1),
       {root: 4},
-      generateWitness(cm.stateHashes, 2)
+      generateWitness(cm.lastCalldata, 2)
     )
   ).toBe(true);
 });


### PR DESCRIPTION
It looks like a commit was missing from https://github.com/statechannels/dispute-game/pull/23.

This PR completes PR #23 by renaming `stateHashes` to `lastCalldata`. The rename hopefully discourages the reading `lastCalldata` inside the ChallengeManager (as it would not be possible to read calldata from past transactions in a contract).